### PR TITLE
fix(app): set template menu to align start & width to fit content

### DIFF
--- a/app/components/TemplateMenu.vue
+++ b/app/components/TemplateMenu.vue
@@ -30,6 +30,7 @@
       label: 'Changelog',
       to: 'https://changelog-template.nuxt.dev/'
     }]"
+    :content="{ align: 'start' }"
     :ui="{ content: 'min-w-fit' }"
     size="xs"
   >


### PR DESCRIPTION
Tiny tweak by referring https://ui.nuxt.com/docs/components/select-menu#with-full-content-width to use `min-w-fit`. 

Question: Should this be propagated to other templates as well? Just wanted to confirm first.

| Before | After (align start + min-w-fit) | 
| --- | --- |
| <img width="360" height="340" alt="chrome_2fHhFAG7X8" src="https://github.com/user-attachments/assets/a8e01607-9a2a-4441-9340-91b8246ae76c" /> | <img width="360" height="340" alt="chrome_5beKK3Jjtw" src="https://github.com/user-attachments/assets/d0038c2c-3c50-403b-8cc3-d783958ce1ea" /> |

