### PR TITLE
fix: strip trailing slash from path before using as asyncData key

### DIFF
--- a/app/components/PageHeaderLinks.vue
+++ b/app/components/PageHeaderLinks.vue
@@ -7,7 +7,7 @@ const toast = useToast()
 const { copy, copied } = useClipboard()
 const site = useSiteConfig()
 
-const routePath = computed(() => withoutTrailingSlash(route.path) || '/')
+const routePath = computed(() => withoutTrailingSlash(route.path))
 const mdPath = computed(() => `${site.url}/raw${routePath.value}.md`)
 
 const items = [

--- a/app/components/PageHeaderLinks.vue
+++ b/app/components/PageHeaderLinks.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
+import { withoutTrailingSlash } from 'ufo'
 
 const route = useRoute()
 const toast = useToast()
 const { copy, copied } = useClipboard()
 const site = useSiteConfig()
 
-const mdPath = computed(() => `${site.url}/raw${route.path}.md`)
+const routePath = computed(() => withoutTrailingSlash(route.path) || '/')
+const mdPath = computed(() => `${site.url}/raw${routePath.value}.md`)
 
 const items = [
   {
@@ -24,7 +26,7 @@ const items = [
     label: 'View as Markdown',
     icon: 'i-simple-icons:markdown',
     target: '_blank',
-    to: `/raw${route.path}.md`
+    to: `/raw${routePath.value}.md`
   },
   {
     label: 'Open in ChatGPT',
@@ -41,7 +43,7 @@ const items = [
 ]
 
 async function copyPage() {
-  copy(await $fetch<string>(`/raw${route.path}.md`))
+  copy(await $fetch<string>(`/raw${routePath.value}.md`))
 }
 </script>
 

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ContentNavigationItem } from '@nuxt/content'
 import { findPageHeadline } from '@nuxt/content/utils'
+import { withoutTrailingSlash } from 'ufo'
 
 definePageMeta({
   layout: 'docs'
@@ -9,14 +10,15 @@ definePageMeta({
 const route = useRoute()
 const { toc } = useAppConfig()
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
+const routePath = computed(() => withoutTrailingSlash(route.path) || '/')
 
-const { data: page } = await useAsyncData(route.path, () => queryCollection('docs').path(route.path).first())
+const { data: page } = await useAsyncData(routePath.value, () => queryCollection('docs').path(routePath.value).first())
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: surround } = await useAsyncData(`${route.path}-surround`, () => {
-  return queryCollectionItemSurroundings('docs', route.path, {
+const { data: surround } = await useAsyncData(`${routePath.value}-surround`, () => {
+  return queryCollectionItemSurroundings('docs', routePath.value, {
     fields: ['description']
   })
 })

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -10,7 +10,7 @@ definePageMeta({
 const route = useRoute()
 const { toc } = useAppConfig()
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
-const routePath = computed(() => withoutTrailingSlash(route.path) || '/')
+const routePath = computed(() => withoutTrailingSlash(route.path))
 
 const { data: page } = await useAsyncData(routePath.value, () => queryCollection('docs').path(routePath.value).first())
 if (!page.value) {


### PR DESCRIPTION
context: https://github.com/nuxt/nuxt/issues/36111
https://gitlab.com/eu-os/eu-os.gitlab.io/-/merge_requests/19
https://github.com/nuxt/content/pull/3838

on some hosts there may be trailing slashes, which means the route path should never be directly passed to `useAsyncData`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown page navigation by consistently handling trailing slashes in URLs.
  * Ensured root pages resolve correctly whether their path is empty or ends with a slash.
  * Updated copy, view, external-link, and surrounding-page navigation actions to use consistent, normalized URLs.
  * Reduced unexpected navigation and page-loading differences caused by alternate URL formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->