### PR TITLE
fix(AppHeader): add a visible focus ring to the logo link

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -38,7 +38,10 @@ const { header } = useAppConfig()
       v-else
       #left
     >
-      <NuxtLink :to="header?.to || '/'">
+      <NuxtLink
+        :to="header?.to || '/'"
+        class="focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1"
+      >
         <AppLogo class="w-auto h-6 shrink-0" />
       </NuxtLink>
 


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `docs` and `calendar`:

```
focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1
```

`p-1 -ms-1` gives the outline room to breathe without shifting the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus visibility for the header logo link.
  * Added rounded corners, padding, and adjusted spacing while preserving its existing navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->